### PR TITLE
Fix wikipediaapi attribute error and search failures

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,7 +45,7 @@ class Config:
     # Online Search Configuration
     # Elder Scrolls Wiki API endpoints
     UESP_API_BASE_URL = "https://en.uesp.net/api.php"
-    UESP_SEARCH_URL = "https://en.uesp.net/search.php"
+    UESP_SEARCH_URL = "https://en.uesp.net/wiki"
     
     # Wikipedia API for Elder Scrolls content
     WIKIPEDIA_API_BASE_URL = "https://en.wikipedia.org/api/rest_v1"


### PR DESCRIPTION
Fixes Wikipedia search `AttributeError` and corrects UESP search URLs.

The `wikipediaapi` library's `Wikipedia` object does not have a `.search()` method, leading to an `AttributeError`. This PR implements a direct `aiohttp` call to Wikipedia's search API to resolve this, and also updates UESP configuration and scraping URLs to their correct search endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-b20cab0a-653e-47fc-8cb9-84758367ee80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b20cab0a-653e-47fc-8cb9-84758367ee80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

