### PR TITLE
Refine ai prompts to avoid external references

### DIFF
--- a/example_usage.py
+++ b/example_usage.py
@@ -143,7 +143,7 @@ def example_llm_only():
         
         # Direct LLM prompt
         prompt = """You are an expert on The Elder Scrolls universe. 
-        Please provide a brief overview of the different races in Tamriel."""
+        Please provide a brief overview of the different races in Tamriel. Provide direct, confident answers without mentioning what information may or may not be in the context."""
         
         print("Sending prompt to LLM...")
         response = llm_client.generate_response(prompt)

--- a/llm_client.py
+++ b/llm_client.py
@@ -43,7 +43,7 @@ class OpenRouterClient(LLMClient):
                 "messages": [
                     {
                         "role": "system",
-                        "content": "You are an expert on The Elder Scrolls universe. Answer questions based on the provided lore context. Be accurate, concise, and engaging. If the context doesn't contain relevant information, politely say so."
+                        "content": "You are an expert on The Elder Scrolls universe. Answer questions based on the provided lore context. Be accurate, concise, and engaging. Provide direct, confident answers without mentioning what information may or may not be in the context."
                     },
                     {
                         "role": "user",
@@ -92,7 +92,7 @@ class OllamaClient(LLMClient):
             
             payload = {
                 "model": self.model,
-                "prompt": f"""You are an expert on The Elder Scrolls universe. Answer questions based on the provided lore context. Be accurate, concise, and engaging. If the context doesn't contain relevant information, politely say so.
+                "prompt": f"""You are an expert on The Elder Scrolls universe. Answer questions based on the provided lore context. Be accurate, concise, and engaging. Provide direct, confident answers without mentioning what information may or may not be in the context.
 
 Context: {prompt}
 
@@ -144,7 +144,7 @@ class LMStudioClient(LLMClient):
                 "messages": [
                     {
                         "role": "system",
-                        "content": "You are an expert on The Elder Scrolls universe. Answer questions based on the provided lore context. Be accurate, concise, and engaging. If the context doesn't contain relevant information, politely say so."
+                        "content": "You are an expert on The Elder Scrolls universe. Answer questions based on the provided lore context. Be accurate, concise, and engaging. Provide direct, confident answers without mentioning what information may or may not be in the context."
                     },
                     {
                         "role": "user",
@@ -231,7 +231,7 @@ I don't have any relevant information about this in my Elder Scrolls knowledge b
 
 Question: {question}
 
-Please provide a clear, accurate, and engaging answer based on the Elder Scrolls lore. If the context doesn't contain sufficient information to answer the question completely, acknowledge what you know and what might be missing. Always maintain the rich, immersive tone of Elder Scrolls lore."""
+Please provide a clear, accurate, and engaging answer based on the Elder Scrolls lore. Provide direct, confident answers without mentioning what information may or may not be in the context. Always maintain the rich, immersive tone of Elder Scrolls lore."""
         
         return prompt
     


### PR DESCRIPTION
Adjust LLM prompts to prevent the AI from mentioning the provided context or drawing on broader lore.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0e107ce-d5a5-453d-95c5-4479267eae3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0e107ce-d5a5-453d-95c5-4479267eae3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

